### PR TITLE
Refine python script translation of matlab files

### DIFF
--- a/deform/Q.py
+++ b/deform/Q.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def Q(h, t, r, n):
     """
     Kernels calculation.
@@ -18,6 +19,9 @@ def Q(h, t, r, n):
         numpy.ndarray
             Calculated kernel values.
     """
+    t = np.asarray(t, dtype=float)
+    r = np.asarray(r, dtype=float)
+
     E = h**2 + r**2 - t**2
     D = np.sqrt(E**2 + 4 * h**2 * t**2)
     D3 = D**3
@@ -49,6 +53,6 @@ def Q(h, t, r, n):
     elif n == 61:  # Q6*r
         K = 1 - (h * np.sqrt(D + E) + t * np.sqrt(D - E)) / (D * np.sqrt(2))
     else:
-        raise ValueError("Invalid kernel type n.")
+        K = np.array([])
 
     return K

--- a/deform/dc3d4.py
+++ b/deform/dc3d4.py
@@ -155,3 +155,4 @@ def dc3d4(alpha, x, y, dip, al1, al2, aw1, aw2, disl1, disl2):
                 u -= du
 
     return u[0, :], u[1, :], u[2, :], 0
+

--- a/deform/dc3d4.py
+++ b/deform/dc3d4.py
@@ -45,7 +45,10 @@ def dc3d4(alpha, x, y, dip, al1, al2, aw1, aw2, disl1, disl2):
     c0_cd = np.cos(dip * pl8)
     if abs(c0_cd) < EPS:
         c0_cd = F0
-        c0_sd = F1 if c0_sd > F0 else -F1
+        if c0_sd > F0:
+            c0_sd = F1
+        elif c0_sd < F0:
+            c0_sd = -F1
     c0_cdcd = c0_cd * c0_cd
     c0_sdcd = c0_sd * c0_cd
 
@@ -61,18 +64,45 @@ def dc3d4(alpha, x, y, dip, al1, al2, aw1, aw2, disl1, disl2):
         for j in range(2):
             xi = x - al1 if j == 0 else x - al2
 
-            # Station geometry constants
-            c2_r = np.sqrt(xi**2 + et**2 + q**2)
+            # Calculate station geometry constants with singularity handling
+            etq_max = np.maximum(np.abs(et), np.abs(q))
+            dc_max = np.maximum(np.abs(xi), etq_max)
+
+            xi = xi - (np.abs(xi / dc_max) < EPS) * xi
+            xi = xi - (np.abs(xi) < EPS) * xi
+            et = et - (np.abs(et / dc_max) < EPS) * et
+            et = et - (np.abs(et) < EPS) * et
+            q = q - (np.abs(q / dc_max) < EPS) * q
+            q = q - (np.abs(q) < EPS) * q
+
+            dc_xi = xi
+            dc_et = et
+            dc_q = q
+
+            c2_r = np.sqrt(dc_xi**2 + dc_et**2 + dc_q**2)
 
             if np.any(c2_r == F0):
                 return np.zeros(nx), np.zeros(nx), np.zeros(nx), 1
 
-            c2_y = et * c0_cd + q * c0_sd
-            c2_d = et * c0_sd - q * c0_cd
+            c2_y = dc_et * c0_cd + dc_q * c0_sd
+            c2_d = dc_et * c0_sd - dc_q * c0_cd
 
-            c2_x11 = np.ones(nx) / (c2_r * (c2_r + xi))
-            c2_ale = np.log(c2_r + et)
-            c2_y11 = np.ones(nx) / (c2_r * (c2_r + et))
+            with np.errstate(divide='ignore', invalid='ignore'):
+                c2_tt = np.arctan((dc_xi * dc_et) / (dc_q * c2_r))
+            c2_tt = np.where(dc_q == 0, F0, c2_tt)
+
+            c2_x11 = F1 / (c2_r * (c2_r + dc_xi))
+            c2_x11 = c2_x11 - ((dc_xi < F0) & (dc_q == F0) & (dc_et == F0)) * c2_x11
+
+            c2_ale_msk1 = ((dc_et < F0) & (dc_q == F0) & (dc_xi == F0)).astype(float)
+            c2_ale_msk2 = F1 - c2_ale_msk1
+            ret1 = c2_r - dc_et
+            ret2 = c2_r + dc_et
+            c2_ale = c2_ale_msk1 * (-np.log(ret1)) + c2_ale_msk2 * np.log(ret2)
+            c2_y11 = F1 / (c2_r * ret2)
+
+            if np.any(((q == F0) & (((jxi & (et == F0)) | (jet & (xi == F0)))) ) | (c2_r == F0)):
+                return np.zeros(nx), np.zeros(nx), np.zeros(nx), 2
 
             # Part B of displacement calculations
             rd = c2_r + c2_d
@@ -96,27 +126,30 @@ def dc3d4(alpha, x, y, dip, al1, al2, aw1, aw2, disl1, disl2):
             qy = q * c2_y11
 
             # Strike-slip contribution
-            if np.any(disl1) != F0:
+            if disl1 != F0:
                 du2 = np.zeros((3, nx))
-                du2[0, :] = -xi * qy - c0_alp3 * ai1 * c0_sd
+                du2[0, :] = -xi * qy - c2_tt - c0_alp3 * ai1 * c0_sd
                 du2[1, :] = -q / c2_r + c0_alp3 * c2_y / rd * c0_sd
                 du2[2, :] = q * qy - c0_alp3 * ai2 * c0_sd
-                dub += (disl1 / PI2) * du2
+                dub = (disl1 / PI2) * du2
+            else:
+                dub = np.zeros((3, nx))
 
             # Dip-slip contribution
-            if np.any(disl2) != F0:
+            if disl2 != F0:
                 du2 = np.zeros((3, nx))
                 du2[0, :] = -q / c2_r + c0_alp3 * ai3 * c0_sdcd
-                du2[1, :] = -et * qx - c0_alp3 * xi / rd * c0_sdcd
+                du2[1, :] = -et * qx - c2_tt - c0_alp3 * xi / rd * c0_sdcd
                 du2[2, :] = q * qx + c0_alp3 * ai4 * c0_sdcd
-                dub += (disl2 / PI2) * du2
+                dub = dub + (disl2 / PI2) * du2
 
             du = np.zeros((3, nx))
             du[0, :] = dub[0, :]
             du[1, :] = dub[1, :] * c0_cd - dub[2, :] * c0_sd
             du[2, :] = dub[1, :] * c0_sd + dub[2, :] * c0_cd
 
-            if (j + k) != 3:
+            # Accumulate or subtract based on the quadrant as in the MATLAB routine
+            if j == k:
                 u += du
             else:
                 u -= du

--- a/deform/dc3d5.py
+++ b/deform/dc3d5.py
@@ -64,64 +64,97 @@ def dc3d5(alpha, x, y, dip, al1, al2, aw1, aw2, disl1, disl2, disl3):
         for j in range(2):
             xi = x - al1 if j == 0 else x - al2
 
-            c2_r = np.sqrt(xi**2 + et**2 + q**2)
+            # Station geometry constants with singularity handling
+            etq_max = np.maximum(np.abs(et), np.abs(q))
+            dc_max = np.maximum(np.abs(xi), etq_max)
+
+            xi = xi - (np.abs(xi / dc_max) < EPS) * xi
+            xi = xi - (np.abs(xi) < EPS) * xi
+            et = et - (np.abs(et / dc_max) < EPS) * et
+            et = et - (np.abs(et) < EPS) * et
+            q = q - (np.abs(q / dc_max) < EPS) * q
+            q = q - (np.abs(q) < EPS) * q
+
+            dc_xi = xi
+            dc_et = et
+            dc_q = q
+
+            c2_r = np.sqrt(dc_xi**2 + dc_et**2 + dc_q**2)
 
             if np.any(c2_r == F0):
                 return np.zeros(nx), np.zeros(nx), np.zeros(nx), 1
 
-            c2_y = et * c0_cd + q * c0_sd
-            c2_d = et * c0_sd - q * c0_cd
+            c2_y = dc_et * c0_cd + dc_q * c0_sd
+            c2_d = dc_et * c0_sd - dc_q * c0_cd
+
+            with np.errstate(divide='ignore', invalid='ignore'):
+                c2_tt = np.arctan((dc_xi * dc_et) / (dc_q * c2_r))
+            c2_tt = np.where(dc_q == 0, F0, c2_tt)
+
+            c2_x11 = F1 / (c2_r * (c2_r + dc_xi))
+            c2_x11 = c2_x11 - ((dc_xi < F0) & (dc_q == F0) & (dc_et == F0)) * c2_x11
+
+            c2_ale_msk1 = ((dc_et < F0) & (dc_q == F0) & (dc_xi == F0)).astype(float)
+            c2_ale_msk2 = F1 - c2_ale_msk1
+            ret1 = c2_r - dc_et
+            ret2 = c2_r + dc_et
+            c2_ale = c2_ale_msk1 * (-np.log(ret1)) + c2_ale_msk2 * np.log(ret2)
+            c2_y11 = F1 / (c2_r * ret2)
+
+            if np.any(((q == F0) & (((jxi & (et == F0)) | (jet & (xi == F0)))) ) | (c2_r == F0)):
+                return np.zeros(nx), np.zeros(nx), np.zeros(nx), 2
 
             rd = c2_r + c2_d
             if c0_cd != F0:
                 xx = np.sqrt(xi**2 + q**2)
-                ai4 = (xi != 0) * (
-                    (F1 / c0_cdcd) * (xi / rd * c0_sdcd +
-                                      F2 * np.arctan((et * (xx + q * c0_cd) + xx * (c2_r + xx) * c0_sd) /
-                                                     (xi * (c2_r + xx) * c0_cd)))
-                )
-                ai3 = (c2_y * c0_cd / rd - np.log(c2_r + et) + c0_sd * np.log(rd)) / c0_cdcd
+                ai4 = (xi != 0) * ((F1 / c0_cdcd) * (xi / rd * c0_sdcd +
+                                  F2 * np.arctan((et * (xx + q * c0_cd) +
+                                                  xx * (c2_r + xx) * c0_sd) /
+                                                 (xi * (c2_r + xx) * c0_cd))))
+                ai3 = (c2_y * c0_cd / rd - c2_ale + c0_sd * np.log(rd)) / c0_cdcd
             else:
                 rd2 = rd**2
-                ai3 = (et / rd + c2_y * q / rd2 - np.log(c2_r + et)) / F2
+                ai3 = (et / rd + c2_y * q / rd2 - c2_ale) / F2
                 ai4 = (xi * c2_y / rd2) / F2
 
             ai1 = -xi / rd * c0_cd - ai4 * c0_sd
             ai2 = np.log(rd) + ai3 * c0_sd
 
-            qx = q * (1 / (c2_r * (c2_r + xi)))
-            qy = q * (1 / (c2_r * (c2_r + et)))
+            qx = q * c2_x11
+            qy = q * c2_y11
 
             # Strike-slip contribution
-            if np.any(disl1 != F0):
+            if disl1 != F0:
                 du2 = np.zeros((3, nx))
-                du2[0, :] = -xi * qy - c0_alp3 * ai1 * c0_sd
+                du2[0, :] = -xi * qy - c2_tt - c0_alp3 * ai1 * c0_sd
                 du2[1, :] = -q / c2_r + c0_alp3 * c2_y / rd * c0_sd
                 du2[2, :] = q * qy - c0_alp3 * ai2 * c0_sd
-                dub += (disl1 / PI2) * du2
+                dub = (disl1 / PI2) * du2
+            else:
+                dub = np.zeros((3, nx))
 
             # Dip-slip contribution
-            if np.any(disl2 != F0):
+            if disl2 != F0:
                 du2 = np.zeros((3, nx))
                 du2[0, :] = -q / c2_r + c0_alp3 * ai3 * c0_sdcd
-                du2[1, :] = -et * qx - c0_alp3 * xi / rd * c0_sdcd
+                du2[1, :] = -et * qx - c2_tt - c0_alp3 * xi / rd * c0_sdcd
                 du2[2, :] = q * qx + c0_alp3 * ai4 * c0_sdcd
-                dub += (disl2 / PI2) * du2
+                dub = dub + (disl2 / PI2) * du2
 
             # Tensile contribution
-            if np.any(disl3 != F0):
+            if disl3 != F0:
                 du2 = np.zeros((3, nx))
                 du2[0, :] = q * qy - c0_alp3 * ai3 * c0_sdsd
                 du2[1, :] = q * qx + c0_alp3 * xi / rd * c0_sdsd
-                du2[2, :] = et * qx + xi * qy - c0_alp3 * ai4 * c0_sdsd
-                dub += (disl3 / PI2) * du2
+                du2[2, :] = et * qx + xi * qy - c0_alp3 * ai4 * c0_sdsd - c2_tt
+                dub = dub + (disl3 / PI2) * du2
 
             du = np.zeros((3, nx))
             du[0, :] = dub[0, :]
             du[1, :] = dub[1, :] * c0_cd - dub[2, :] * c0_sd
             du[2, :] = dub[1, :] * c0_sd + dub[2, :] * c0_cd
 
-            if (j + k) != 3:
+            if j == k:
                 u += du
             else:
                 u -= du

--- a/deform/dc3d6.py
+++ b/deform/dc3d6.py
@@ -37,7 +37,6 @@ def dc3d6(alpha, x, y, depth, dip, al1, al2, aw1, aw2, disl1, disl2, disl3):
     nx = len(x)
 
     u = np.zeros((3, nx))
-    dub = np.zeros((3, nx))
 
     # Medium and fault dip constants
     c0_alp3 = (F1 - alpha) / alpha
@@ -45,16 +44,14 @@ def dc3d6(alpha, x, y, depth, dip, al1, al2, aw1, aw2, disl1, disl2, disl3):
     pl8 = PI2 / 360
     c0_sd = np.sin(dip * pl8)
     c0_cd = np.cos(dip * pl8)
-
     if abs(c0_cd) < EPS:
         c0_cd = F0
         c0_sd = F1 if c0_sd > F0 else -F1
-
-    c0_cdcd = c0_cd**2
+    c0_cdcd = c0_cd * c0_cd
     c0_sdcd = c0_sd * c0_cd
-    c0_sdsd = c0_sd**2
+    c0_sdsd = c0_sd * c0_sd
 
-    z = 0  # This version assumes surface deformation
+    z = 0  # surface deformation
     d = depth + z
 
     # Geometric parameters
@@ -69,64 +66,98 @@ def dc3d6(alpha, x, y, depth, dip, al1, al2, aw1, aw2, disl1, disl2, disl3):
         for j in range(2):
             xi = x - al1 if j == 0 else x - al2
 
-            c2_r = np.sqrt(xi**2 + et**2 + q**2)
+            # Station geometry constants with singularity handling
+            etq_max = np.maximum(np.abs(et), np.abs(q))
+            dc_max = np.maximum(np.abs(xi), etq_max)
 
+            xi = xi - (np.abs(xi / dc_max) < EPS) * xi
+            xi = xi - (np.abs(xi) < EPS) * xi
+            et = et - (np.abs(et / dc_max) < EPS) * et
+            et = et - (np.abs(et) < EPS) * et
+            q = q - (np.abs(q / dc_max) < EPS) * q
+            q = q - (np.abs(q) < EPS) * q
+
+            dc_xi = xi
+            dc_et = et
+            dc_q = q
+
+            c2_r = np.sqrt(dc_xi**2 + dc_et**2 + dc_q**2)
             if np.any(c2_r == F0):
                 return np.zeros(nx), np.zeros(nx), np.zeros(nx), 1
 
-            c2_y = et * c0_cd + q * c0_sd
-            c2_d = et * c0_sd - q * c0_cd
+            c2_y = dc_et * c0_cd + dc_q * c0_sd
+            c2_d = dc_et * c0_sd - dc_q * c0_cd
+
+            with np.errstate(divide='ignore', invalid='ignore'):
+                c2_tt = np.arctan((dc_xi * dc_et) / (dc_q * c2_r))
+            c2_tt = np.where(dc_q == 0, F0, c2_tt)
+
+            c2_x11 = F1 / (c2_r * (c2_r + dc_xi))
+            c2_x11 = c2_x11 - ((dc_xi < F0) & (dc_q == F0) & (dc_et == F0)) * c2_x11
+
+            c2_ale_msk1 = ((dc_et < F0) & (dc_q == F0) & (dc_xi == F0)).astype(float)
+            c2_ale_msk2 = F1 - c2_ale_msk1
+            ret1 = c2_r - dc_et
+            ret2 = c2_r + dc_et
+            c2_ale = c2_ale_msk1 * (-np.log(ret1)) + c2_ale_msk2 * np.log(ret2)
+            c2_y11 = F1 / (c2_r * ret2)
+
+            if np.any(((dc_q == F0) & ((jxi & (dc_et == F0)) | (jet & (dc_xi == F0)))) | (c2_r == F0)):
+                return np.zeros(nx), np.zeros(nx), np.zeros(nx), 2
 
             rd = c2_r + c2_d
+
             if c0_cd != F0:
-                xx = np.sqrt(xi**2 + q**2)
-                ai4 = (xi != 0) * (
-                    (F1 / c0_cdcd) * (xi / rd * c0_sdcd +
-                                      F2 * np.arctan((et * (xx + q * c0_cd) + xx * (c2_r + xx) * c0_sd) /
-                                                     (xi * (c2_r + xx) * c0_cd)))
-                )
-                ai3 = (c2_y * c0_cd / rd - np.log(c2_r + et) + c0_sd * np.log(rd)) / c0_cdcd
+                xx = np.sqrt(dc_xi**2 + dc_q**2)
+                ai4 = (dc_xi != 0) * ((F1 / c0_cdcd) *
+                                      (dc_xi / rd * c0_sdcd +
+                                       F2 * np.arctan((dc_et * (xx + dc_q * c0_cd) +
+                                                       xx * (c2_r + xx) * c0_sd) /
+                                                      (dc_xi * (c2_r + xx) * c0_cd))))
+                ai3 = (c2_y * c0_cd / rd - c2_ale + c0_sd * np.log(rd)) / c0_cdcd
             else:
                 rd2 = rd**2
-                ai3 = (et / rd + c2_y * q / rd2 - np.log(c2_r + et)) / F2
-                ai4 = (xi * c2_y / rd2) / F2
+                ai3 = (dc_et / rd + c2_y * dc_q / rd2 - c2_ale) / F2
+                ai4 = (dc_xi * c2_y / rd2) / F2
 
-            ai1 = -xi / rd * c0_cd - ai4 * c0_sd
+            ai1 = -dc_xi / rd * c0_cd - ai4 * c0_sd
             ai2 = np.log(rd) + ai3 * c0_sd
 
-            qx = q * (1 / (c2_r * (c2_r + xi)))
-            qy = q * (1 / (c2_r * (c2_r + et)))
+            qx = dc_q * c2_x11
+            qy = dc_q * c2_y11
 
             # Strike-slip contribution
-            if np.any(disl1 != F0):
+            if disl1 != F0:
                 du2 = np.zeros((3, nx))
-                du2[0, :] = -xi * qy - c0_alp3 * ai1 * c0_sd
-                du2[1, :] = -q / c2_r + c0_alp3 * c2_y / rd * c0_sd
-                du2[2, :] = q * qy - c0_alp3 * ai2 * c0_sd
-                dub += (disl1 / PI2) * du2
+                du2[0, :] = -dc_xi * qy - c2_tt - c0_alp3 * ai1 * c0_sd
+                du2[1, :] = -dc_q / c2_r + c0_alp3 * c2_y / rd * c0_sd
+                du2[2, :] = dc_q * qy - c0_alp3 * ai2 * c0_sd
+                dub = (disl1 / PI2) * du2
+            else:
+                dub = np.zeros((3, nx))
 
             # Dip-slip contribution
-            if np.any(disl2 != F0):
+            if disl2 != F0:
                 du2 = np.zeros((3, nx))
-                du2[0, :] = -q / c2_r + c0_alp3 * ai3 * c0_sdcd
-                du2[1, :] = -et * qx - c0_alp3 * xi / rd * c0_sdcd
-                du2[2, :] = q * qx + c0_alp3 * ai4 * c0_sdcd
-                dub += (disl2 / PI2) * du2
+                du2[0, :] = -dc_q / c2_r + c0_alp3 * ai3 * c0_sdcd
+                du2[1, :] = -dc_et * qx - c2_tt - c0_alp3 * dc_xi / rd * c0_sdcd
+                du2[2, :] = dc_q * qx + c0_alp3 * ai4 * c0_sdcd
+                dub = dub + (disl2 / PI2) * du2
 
             # Tensile contribution
-            if np.any(disl3 != F0):
+            if disl3 != F0:
                 du2 = np.zeros((3, nx))
-                du2[0, :] = q * qy - c0_alp3 * ai3 * c0_sdsd
-                du2[1, :] = q * qx + c0_alp3 * xi / rd * c0_sdsd
-                du2[2, :] = et * qx + xi * qy - c0_alp3 * ai4 * c0_sdsd
-                dub += (disl3 / PI2) * du2
+                du2[0, :] = dc_q * qy - c0_alp3 * ai3 * c0_sdsd
+                du2[1, :] = dc_q * qx + c0_alp3 * dc_xi / rd * c0_sdsd
+                du2[2, :] = dc_et * qx + dc_xi * qy - c0_alp3 * ai4 * c0_sdsd - c2_tt
+                dub = dub + (disl3 / PI2) * du2
 
             du = np.zeros((3, nx))
             du[0, :] = dub[0, :]
             du[1, :] = dub[1, :] * c0_cd - dub[2, :] * c0_sd
             du[2, :] = dub[1, :] * c0_sd + dub[2, :] * c0_cd
 
-            if (j + k) != 3:
+            if j == k:
                 u += du
             else:
                 u -= du

--- a/deform/disloc3d3.py
+++ b/deform/disloc3d3.py
@@ -1,6 +1,6 @@
 import numpy as np
-from dc3d4 import dc3d4
-from dc3d5 import dc3d5
+from .dc3d4 import dc3d4
+from .dc3d5 import dc3d5
 
 def disloc3d3(m, x, lambda_, mu):
     """
@@ -58,8 +58,8 @@ def disloc3d3(m, x, lambda_, mu):
         aw2 = np.full(nx, hmax / sindip)
 
         # Reject data which breaks the surface
-        if np.any(hmin < 0):
-            raise ValueError("ERROR: Fault top above ground surface")
+        if hmin < 0:
+            print("ERROR: Fault top above ground surface")
 
         hmin += (hmin == 0) * 1e-5
 
@@ -78,10 +78,13 @@ def disloc3d3(m, x, lambda_, mu):
             # Tensile only component solution
             ux, uy, uz, err = dc3d5(alpha, X, Y, -dip, al1, al2, aw1, aw2, 0, 0, opening)
         else:
-            raise ValueError("10th row in geometry file must be 1 (double couple) or 2 (tensile)")
+            raise ValueError(
+                "10th row in geometry file must be 1 (double couple) or 2 (tensile)"
+            )
 
         if err != 0:
-            raise RuntimeError(f"Error code in dc3d3: {err}")
+            print("error code in dc3d3... stopping!")
+            return U, err
 
         U[0, :] += ct * ux + st * uy
         U[1, :] += -st * ux + ct * uy

--- a/deform/disloc3d4.py
+++ b/deform/disloc3d4.py
@@ -1,27 +1,29 @@
 import numpy as np
-from dc3d4 import dc3d4
-from dc3d5 import dc3d5
-from dc3d6 import dc3d6
+from .dc3d4 import dc3d4
+from .dc3d5 import dc3d5
+from .dc3d6 import dc3d6
 
 def disloc3d4(m, x, lambda_, mu):
     """
     Returns the deformation at points 'x', given dislocation model 'm'.
 
-    Parameters:
-        m: numpy.ndarray
-            Dislocation model matrix (9xj).
-        x: numpy.ndarray
-            Observation coordinates matrix (2xi).
-        lambda_: float
-            First Lame parameter.
-        mu: float
-            Second Lame parameter (shear modulus).
+    Parameters
+    ----------
+    m : numpy.ndarray
+        Dislocation model matrix (10 x j).
+    x : numpy.ndarray
+        Observation coordinates matrix (2 x i).
+    lambda_ : float
+        First Lame parameter.
+    mu : float
+        Second Lame parameter (shear modulus).
 
-    Returns:
-        U: numpy.ndarray
-            Displacements (east, north, and up components).
-        flag: int
-            Error flag (0 if no error).
+    Returns
+    -------
+    U : numpy.ndarray
+        Displacements (east, north, and up components).
+    flag : int
+        Error flag (0 if no error).
     """
     DEG2RAD = 2 * np.pi / 360
     nfaults = m.shape[1]
@@ -32,7 +34,6 @@ def disloc3d4(m, x, lambda_, mu):
 
     # Calculate alpha
     alpha = (lambda_ + mu) / (lambda_ + 2 * mu)
-    # print(f"Alpha: {alpha}")
 
     # Loop over models
     for i in range(nfaults):
@@ -61,14 +62,13 @@ def disloc3d4(m, x, lambda_, mu):
         rrake = (rake + 90) * DEG2RAD
         ud = np.full(nx, slip * np.cos(rrake))
         us = np.full(nx, -slip * np.sin(rrake))
-        print(f'us: {us}')
         opening = np.full(nx, slip)
         halflen = length / 2
         al2 = np.full(nx, halflen)
         al1 = -al2
 
-        if np.any(hmin < 0):
-            raise ValueError("ERROR: Fault top above ground surface")
+        if hmin < 0:
+            print("ERROR: Fault top above ground surface")
         
         hmin += (hmin == 0) * 1e-5  # Adjust if hmin is zero
 
@@ -86,10 +86,12 @@ def disloc3d4(m, x, lambda_, mu):
         elif m[9, i] == 3:  # Tensile only component solution, sills
             ux, uy, uz, err = dc3d6(alpha, X, Y, fdepth, -dip, al1, al2, aw1, aw2, 0, 0, opening)
         else:
-            raise ValueError("10th row in geometry file must be 1 (=double couple) or 2 (tensile)")
+            print("10th row in geometry file must be 1 (=double couple) or 2 (tensile)")
+            return U, 1
 
         if err != 0:
-            raise RuntimeError(f"Error code in dc3d3: {err}")
+            print("error code in dc3d3... stopping!")
+            return U, err
 
         U[0, :] += ct * ux + st * uy
         U[1, :] += -st * ux + ct * uy

--- a/deform/fpkernel.py
+++ b/deform/fpkernel.py
@@ -1,24 +1,28 @@
 import numpy as np
 
+
 def fpkernel(h, t, r, n):
-    """
-    Kernels calculation.
+    """Kernels calculation.
 
-    Parameters:
-        h: float
-            Parameter h used in calculations.
-        t: numpy.ndarray
-            Array of t values.
-        r: numpy.ndarray
-            Array of r values.
-        n: int
-            Kernel type (1, 2, 3, or 4).
+    Parameters
+    ----------
+    h : float
+        Parameter h used in calculations.
+    t : float
+        Scalar t value.
+    r : array_like
+        Array of r values.
+    n : int
+        Kernel type (1, 2, 3, or 4).
 
-    Returns:
-        numpy.ndarray
-            Calculated kernel values.
+    Returns
+    -------
+    numpy.ndarray
+        Calculated kernel values.
     """
-    p = 4 * h**2
+    r = np.asarray(r, dtype=float)
+    t = float(np.asarray(t, dtype=float))
+    p = 4 * h ** 2
 
     if n == 1:  # KN
         K = p * h * (KG(t - r, p) - KG(t + r, p))
@@ -27,43 +31,36 @@ def fpkernel(h, t, r, n):
         Dlt = 1e-6
         a = t + r
         b = t - r
-        y = a**2
-        z = b**2
-        g = 2 * p * h * (p**2 + 6 * p * (t**2 + r**2) + 5 * (a * b)**2)
-        s = ((p + z) * (p + y))**2
+        y = a ** 2
+        z = b ** 2
+        g = 2 * p * h * (p ** 2 + 6 * p * (t ** 2 + r ** 2) + 5 * (a * b) ** 2)
+        s = ((p + z) * (p + y)) ** 2
         s = g / s
-        if np.isscalar(t):
-            t = np.full_like(r, t)
-        trbl = -4 * h / (p + t**2) * np.ones_like(t)
-        # print(trbl)
-        # print(t)
-        # print(r)
-        rs = np.where(r > Dlt)
-        # print(rs)
-        if np.all(t < Dlt):
-            trbl = -4 * h / (p + r**2)
+        trbl = -4 * h / (p + t ** 2) * np.ones_like(r)
+        rs = r > Dlt
+        if t < Dlt:
+            trbl = -4 * h / (p + r ** 2)
         else:
             trbl[rs] = h / t / r[rs] * np.log((p + z[rs]) / (p + y[rs]))
-
         K = trbl + s + h * (KERN(b, p) + KERN(a, p))
 
     elif n == 3:  # KM
-        y = (t + r)**2
-        z = (t - r)**2
-        a = ((p + y) * (p + z))**2
+        y = (t + r) ** 2
+        z = (t - r) ** 2
+        a = ((p + y) * (p + z)) ** 2
         c = t + r
         d = t - r
-        b = p * t * ((3 * p**2 - (c * d)**2 + 2 * p * (t**2 + r**2)) / a)
+        b = p * t * ((3 * p ** 2 - (c * d) ** 2 + 2 * p * (t ** 2 + r ** 2)) / a)
         a = p / 2 * (c * KG(c, p) + d * KG(d, p))
         K = b - a
 
     elif n == 4:  # KM1(t,r) = KM(r,t)
-        y = (t + r)**2
-        z = (t - r)**2
-        a = ((p + y) * (p + z))**2
+        y = (t + r) ** 2
+        z = (t - r) ** 2
+        a = ((p + y) * (p + z)) ** 2
         c = t + r
         d = -t + r
-        b = p * r * ((3 * p**2 - (c * d)**2 + 2 * p * (t**2 + r**2)) / a)
+        b = p * r * ((3 * p ** 2 - (c * d) ** 2 + 2 * p * (t ** 2 + r ** 2)) / a)
         a = p / 2 * (c * KG(c, p) + d * KG(d, p))
         K = b - a
 
@@ -72,11 +69,13 @@ def fpkernel(h, t, r, n):
 
     return K
 
+
 def KG(s, p):
-    z = s**2
+    z = s ** 2
     y = p + z
-    return (3 * p - z) / y**3
+    return (3 * p - z) / y ** 3
+
 
 def KERN(w, p):
-    u = (p + w**2)**3
-    return 2 * (p**2 / 2 + w**4 - p * w**2 / 2) / u
+    u = (p + w ** 2) ** 3
+    return 2 * (p ** 2 / 2 + w ** 4 - p * w ** 2 / 2) / u

--- a/deform/fredholm.py
+++ b/deform/fredholm.py
@@ -1,6 +1,6 @@
 import numpy as np
-from fpkernel import fpkernel
-from RtWt import RtWt
+from .fpkernel import fpkernel
+from .RtWt import RtWt
 
 
 def fredholm(h, m, er=1e-7):
@@ -31,19 +31,25 @@ def fredholm(h, m, er=1e-7):
 
     while res > er:
         for i in range(m * NumLegendreTerms):
-            fi[i] = -t[i] + np.sum(Wt * (fi1 * fpkernel(h, t[i], t, 1) +
-                                         psi1 * fpkernel(h, t[i], t, 3)))
-            # print(t)
-            # print(t[i])
-            psi[i] = np.sum(Wt * (psi1 * fpkernel(h, t[i], t, 2) +
-                                   fi1 * fpkernel(h, t[i], t, 4)))
+            fi[i] = -t[i] + np.sum(
+                Wt * (fi1 * fpkernel(h, t[i], t, 1) + psi1 * fpkernel(h, t[i], t, 3))
+            )
+            psi[i] = np.sum(
+                Wt * (psi1 * fpkernel(h, t[i], t, 2) + fi1 * fpkernel(h, t[i], t, 4))
+            )
 
         fi *= lamda
         psi *= lamda
 
-        # Find maximum relative change
-        fim = np.max(np.abs(fi1 - fi)) / np.abs(fi[np.argmax(np.abs(fi1 - fi))])
-        psim = np.max(np.abs(psi1 - psi)) / np.abs(psi[np.argmax(np.abs(psi1 - psi))])
+        # find maximum relative change
+        diff_fi = np.abs(fi1 - fi)
+        im = np.argmax(diff_fi)
+        fim = diff_fi[im] / abs(fi[im])
+
+        diff_psi = np.abs(psi1 - psi)
+        im = np.argmax(diff_psi)
+        psim = diff_psi[im] / abs(psi[im])
+
         res = max(fim, psim)
 
         fi1 = fi.copy()

--- a/deform/generateDeformation.py
+++ b/deform/generateDeformation.py
@@ -1,7 +1,6 @@
 import numpy as np
-from disloc3d4 import disloc3d4
-from rngchn_mogi import rngchn_mogi
-from penny import penny
+from .disloc3d4 import disloc3d4
+from .rngchn_mogi import rngchn_mogi
 
 def generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, Heading, Incidence):
     """
@@ -75,14 +74,15 @@ def generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, Headi
         end2x = model[0, 0] - np.sin(model[2, 0] * DEG2RAD) * model[6, 0] / 2
         end1y = model[1, 0] + np.cos(model[2, 0] * DEG2RAD) * model[6, 0] / 2
         end2y = model[1, 0] - np.cos(model[2, 0] * DEG2RAD) * model[6, 0] / 2
-        c1x = end1x + np.sin((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * model[9, 0]
-        c2x = end1x - np.sin((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * model[8, 0]
-        c3x = end2x - np.sin((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * model[8, 0]
-        c4x = end2x + np.sin((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * model[9, 0]
-        c1y = end1y + np.cos((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * model[9, 0]
-        c2y = end1y - np.cos((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * model[8, 0]
-        c3y = end2y - np.cos((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * model[8, 0]
-        c4y = end2y + np.cos((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * model[9, 0]
+        width = model[8, 0] / 2
+        c1x = end1x + np.sin((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * width
+        c2x = end1x - np.sin((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * width
+        c3x = end2x - np.sin((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * width
+        c4x = end2x + np.sin((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * width
+        c1y = end1y + np.cos((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * width
+        c2y = end1y - np.cos((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * width
+        c3y = end2y - np.cos((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * width
+        c4y = end2y + np.cos((model[2, 0] + 90) * DEG2RAD) * np.cos(model[3, 0] * DEG2RAD) * width
 
     # Set up regular grid for plots
     xx, yy = np.meshgrid(x, y)
@@ -99,11 +99,52 @@ def generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, Headi
         zgrid = U[2, :].reshape(len(y), len(x))
         los_grid = xgrid * LOS_vector[0] + ygrid * LOS_vector[1] + zgrid * LOS_vector[2]
     elif Source_Type == 4:
+        xgrid = rngchn_mogi(
+            1 / 1000,
+            1 / 1000,
+            Mogi['Depth'],
+            -Mogi['Volume'] / 1e9,
+            coords[1, :] / 1000,
+            coords[0, :] / 1000,
+            v,
+            np.tile([1.0, 0.0, 0.0], (coords.shape[1], 1)),
+        )
+        ygrid = rngchn_mogi(
+            1 / 1000,
+            1 / 1000,
+            Mogi['Depth'],
+            -Mogi['Volume'] / 1e9,
+            coords[1, :] / 1000,
+            coords[0, :] / 1000,
+            v,
+            np.tile([0.0, 1.0, 0.0], (coords.shape[1], 1)),
+        )
+        zgrid = rngchn_mogi(
+            1 / 1000,
+            1 / 1000,
+            Mogi['Depth'],
+            -Mogi['Volume'] / 1e9,
+            coords[1, :] / 1000,
+            coords[0, :] / 1000,
+            v,
+            np.tile([0.0, 0.0, 1.0], (coords.shape[1], 1)),
+        )
         los_grid = rngchn_mogi(
-            1 / 1000, 1 / 1000, Mogi['Depth'], -Mogi['Volume'] / 1e9,
-            coords[1, :] / 1000, coords[0, :] / 1000, v, np.tile(LOS_vector, (coords.shape[1], 1))
-        ).reshape(len(y), len(x))
+            1 / 1000,
+            1 / 1000,
+            Mogi['Depth'],
+            -Mogi['Volume'] / 1e9,
+            coords[1, :] / 1000,
+            coords[0, :] / 1000,
+            v,
+            np.tile(LOS_vector, (coords.shape[1], 1)),
+        )
+        xgrid = xgrid.reshape(len(y), len(x))
+        ygrid = ygrid.reshape(len(y), len(x))
+        zgrid = zgrid.reshape(len(y), len(x))
+        los_grid = los_grid.reshape(len(y), len(x))
     elif Source_Type == 5:
+        from .penny import penny
         model = [1, 1, Penny['Depth'] * 1000, Penny['Radius'] * 1000, Penny['Pressure']]
         xgrid, ygrid, zgrid = penny(model, coords.T, mu, v)
         los_grid = xgrid * LOS_vector[0] + ygrid * LOS_vector[1] + zgrid * LOS_vector[2]

--- a/deform/intgr.py
+++ b/deform/intgr.py
@@ -1,5 +1,5 @@
 import numpy as np
-from Q import Q
+from .Q import Q
 
 def intgr(r, fi, psi, h, Wt, t):
     """
@@ -25,19 +25,22 @@ def intgr(r, fi, psi, h, Wt, t):
         Ur: numpy.ndarray
             Radial displacements.
     """
+    r = np.asarray(r)
+    original_shape = r.shape
     if r.ndim == 1:
-        r = r.reshape(1, -1)
+        r = r[np.newaxis, :]
     s1, s2 = r.shape
-    Uz = np.zeros_like(r)
-    Ur = np.zeros_like(r)
+    Uz = np.zeros((s1, s2))
+    Ur = np.zeros((s1, s2))
 
     for i in range(s1):
         for j in range(s2):
-            Uz[i, j] = np.sum(Wt * (fi * (Q(h, t, r[i, j], 1) + h * Q(h, t, r[i, j], 2)) +
-                                    psi * (Q(h, t, r[i, j], 1) / t - Q(h, t, r[i, j], 3))))
+            rr = r[i, j]
+            Uz[i, j] = np.sum(Wt * (fi * (Q(h, t, rr, 1) + h * Q(h, t, rr, 2)) +
+                                    psi * (Q(h, t, rr, 1) / t - Q(h, t, rr, 3))))
 
-            Ur[i, j] = np.sum(Wt * (psi * ((Q(h, t, r[i, j], 4) - h * Q(h, t, r[i, j], 5)) / t -
-                                           Q(h, t, r[i, j], 6) + h * Q(h, t, r[i, j], 7)) -
-                                     h * fi * Q(h, t, r[i, j], 8)))
+            Ur[i, j] = np.sum(Wt * (psi * ((Q(h, t, rr, 4) - h * Q(h, t, rr, 5)) / t -
+                                           Q(h, t, rr, 6) + h * Q(h, t, rr, 7)) -
+                                     h * fi * Q(h, t, rr, 8)))
 
-    return Uz, Ur
+    return Uz.reshape(original_shape), Ur.reshape(original_shape)

--- a/deform/penny.py
+++ b/deform/penny.py
@@ -1,6 +1,6 @@
 import numpy as np
-from fredholm import fredholm
-from intgr import intgr
+from .fredholm import fredholm
+from .intgr import intgr
 
 def penny(mod, coord, mu, v):
     """
@@ -14,15 +14,19 @@ def penny(mod, coord, mu, v):
             P: Pressure in the crack (Pa).
         coord: numpy.ndarray
             Observation coordinates (x, y) in meters.
-        mu: float
-            Shear modulus (Pa).
-        v: float
-            Poisson's ratio.
+        mu: float, ignored
+            Shear modulus (Pa). Overridden to 3e10 Pa.
+        v: float, ignored
+            Poisson's ratio. Overridden to 0.25.
 
     Returns:
         Ux, Uy, Uz: numpy.ndarray
             Displacement components in the x, y, and z directions.
     """
+    # Use fixed material properties as in MATLAB implementation
+    mu = 3e10
+    v = 0.25
+
     R = mod[3]
     P = mod[4]
     x = coord[:, 0] / R

--- a/deform/rngchn_mogi.py
+++ b/deform/rngchn_mogi.py
@@ -1,77 +1,92 @@
 import numpy as np
 
+
 def rngchn_mogi(n1, e1, depth, del_v, ning, eing, v, plook):
+    """Range change from a Mogi source.
+
+    Parameters
+    ----------
+    n1, e1 : float
+        Local north and east coordinates of the source centre (km).
+    depth : float
+        Depth of the Mogi source (km).
+    del_v : float
+        Volume change of the source (km^3).
+    ning, eing : array_like
+        North and east coordinates at which to compute range change.  They may
+        be vectors of equal length or a column/row vector pair for matrix
+        output.
+    v : float
+        Poisson's ratio of the material.
+    plook : array_like
+        Look vector(s).  For vector geometry this should be an ``(N,3)`` array;
+        for matrix geometry a length‑3 vector is expected.
+
+    Returns
+    -------
+    numpy.ndarray
+        Range change at the specified coordinates.
     """
-    Calculate range change based on the Mogi model.
 
-    Parameters:
-        n1: float
-            Local north coordinate of the center of the Mogi source (km).
-        e1: float
-            Local east coordinate of the center of the Mogi source (km).
-        depth: float
-            Depth of the Mogi source (km).
-        del_v: float
-            Volume change of the Mogi source (km^3).
-        ning: numpy.ndarray
-            North coordinates of points to calculate range change.
-        eing: numpy.ndarray
-            East coordinates of points to calculate range change.
-        v: float
-            Poisson's ratio of the material.
-        plook: numpy.ndarray
-            Look vector array.
+    ning = np.asarray(ning)
+    eing = np.asarray(eing)
+    plook = np.asarray(plook)
 
-    Returns:
-        numpy.ndarray
-            Range change at coordinates given in ning and eing.
-    """
-    dsp_coef = 1e6 * del_v * (1 - v) / np.pi
+    dsp_coef = 1_000_000 * del_v * (1 - v) / np.pi
 
-    if ning.ndim == 2 and eing.ndim == 2:
-        print("Calculating a matrix of range change values")
-        m, nn = ning.shape
-        del_rng = np.zeros_like(ning)
-        tmp_n = np.zeros_like(ning)
-        tmp_e = np.zeros_like(eing)
+    # Matrix output: ning is column vector, eing is row vector
+    if (
+        ning.ndim == 2
+        and eing.ndim == 2
+        and ning.shape[1] == 1
+        and eing.shape[0] == 1
+    ):
+        print("Calculating a matrix of rngchg values")
+        m = ning.shape[0]
+        nn = eing.shape[1]
+        tmp_n = np.tile(ning, (1, nn))
+        tmp_e = np.tile(eing, (m, 1))
 
-        for i in range(m):
-            tmp_e[i, :] = eing[i, :]
-        for j in range(nn):
-            tmp_n[:, j] = ning[:, j]
-
-        d_mat = np.sqrt((tmp_n - n1)**2 + (tmp_e - e1)**2)
-        tmp_hyp = (d_mat**2 + depth**2)**1.5
-
+        d_mat = np.sqrt((tmp_n - n1) ** 2 + (tmp_e - e1) ** 2)
+        tmp_hyp = (d_mat ** 2 + depth ** 2) ** 1.5
         del_d = dsp_coef * d_mat / tmp_hyp
         del_f = dsp_coef * depth / tmp_hyp
         azim = np.arctan2((tmp_e - e1), (tmp_n - n1))
-
         e_disp = np.sin(azim) * del_d
         n_disp = np.cos(azim) * del_d
 
+        del_rng = np.empty_like(d_mat)
         for i in range(nn):
-            del_rng[:, i] = np.dot(np.column_stack((e_disp[:, i], n_disp[:, i], del_f[:, i])), plook)
+            del_rng[:, i] = np.dot(
+                np.column_stack((e_disp[:, i], n_disp[:, i], del_f[:, i])), plook
+            )
 
-    elif ning.ndim == 1 and eing.ndim == 1:
-        if ning.size != eing.size:
-            raise ValueError("Coordinate vectors are not of equal length!")
+    # Vector output: ning and eing are co-linear vectors
+    elif (
+        (ning.ndim == 1 and eing.ndim == 1)
+        or (ning.ndim == 2 and ning.shape[0] == 1 and eing.ndim == 2 and eing.shape[0] == 1)
+        or (ning.ndim == 2 and ning.shape[1] == 1 and eing.ndim == 2 and eing.shape[1] == 1)
+    ):
+        ning_vec = ning.ravel()
+        eing_vec = eing.ravel()
+        if ning_vec.size != eing_vec.size:
+            raise ValueError("Coord vectors not equal length!")
 
-        del_rng = np.zeros_like(ning)
-        d_mat = np.sqrt((ning - n1)**2 + (eing - e1)**2)
-        tmp_hyp = (d_mat**2 + depth**2)**1.5
-
+        d_mat = np.sqrt((ning_vec - n1) ** 2 + (eing_vec - e1) ** 2)
+        tmp_hyp = (d_mat ** 2 + depth ** 2) ** 1.5
         del_d = dsp_coef * d_mat / tmp_hyp
         del_f = dsp_coef * depth / tmp_hyp
-        azim = np.arctan2((eing - e1), (ning - n1))
-
+        azim = np.arctan2((eing_vec - e1), (ning_vec - n1))
         e_disp = np.sin(azim) * del_d
         n_disp = np.cos(azim) * del_d
 
-        del_rng = (np.column_stack((e_disp, n_disp, del_f)) * plook).sum(axis=1)
-        del_rng = -1.0 * del_rng / 1000  # Convert from mm to m
+        del_rng = (
+            np.column_stack((e_disp, n_disp, del_f)) * plook
+        ).sum(axis=1)
+        del_rng = -1.0 * del_rng / 1000.0
+        del_rng = del_rng.reshape(ning.shape)
 
     else:
-        raise ValueError("Coordinate vectors make no sense!")
+        raise ValueError("Coord vectors make no sense!")
 
     return del_rng

--- a/deform/trieste_defo.py
+++ b/deform/trieste_defo.py
@@ -1,7 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from phase_colormap import phase_colormap
-from generateDeformation import generateDeformation
+from .generateDeformation import generateDeformation
 
 # Script to produce simulated interferograms
 # Define Source Type
@@ -26,28 +25,35 @@ Quake = {
 
 Dyke = {
     "Strike": 0,             # strike in degrees [0-180]
-    "Dip": -90,                # dip in degrees (usually 90 or near 90)
-    "Opening": 0.5,            # magnitude of opening (perpendincular to plane) in metres
-    "Top_depth": 2,             # depth (measured vertically) to top of dyke in kilometres
-    "Bottom_depth": 5,          # depth (measured vertically) to bottom of dyke in kilometres
-    "Length": 8                 # dyke length in kilometres
+    "Dip": 90,               # dip in degrees (usually 90 or near 90)
+    "Opening": 0.5,          # magnitude of opening (perpendicular to plane) in metres
+    "Top_depth": 2,          # depth (measured vertically) to top of dyke in kilometres
+    "Bottom_depth": 5,       # depth (measured vertically) to bottom of dyke in kilometres
+    "Length": 8              # dyke length in kilometres
 }
 
 Sill = {
-    "Strike": 0, "Dip": 0, "Opening": 1.4,
-    "Depth": 4.5, "Width": 1.4, "Length": 6.046
+    "Strike": 0,
+    "Dip": 10,
+    "Opening": 10,
+    "Depth": 5,
+    "Width": 0.5,
+    "Length": 1,
 }
 
 Mogi = {
-    "Depth": 2.8, "Volume": 10**6.5
+    "Depth": 2.8,
+    "Volume": 10 ** 6.5,
 }
 
 Penny = {
-    "Depth": 5, "Pressure": 10**6, "Radius": 5
+    "Depth": 5,
+    "Pressure": 10 ** 6,
+    "Radius": 5,
 }
 
 # Satellite parameters
-values = np.arange(0, 61, 60)
+values = np.arange(0, 331, 60)
 Incidence = 5  # Incidence angle of satellite in degrees
 
 # Grid parameters
@@ -65,10 +71,15 @@ for Heading in values:
 
     # Plot interferograms
     plt.figure()
-    plt.imshow(los_grid_wrap / 0.028333 * 2 * np.pi - np.pi, extent=[x[0] / 1000, x[-1] / 1000, y[0] / 1000, y[-1] / 1000], cmap=phase_colormap())
-    plt.colorbar(label='radians')
-    plt.title(f'Wrapped Simulation (Heading: {Heading})')
-    plt.xlabel('Easting (km)')
-    plt.ylabel('Northing (km)')
-    plt.axis('image')
+    plt.imshow(
+        los_grid_wrap / 0.028333 * 2 * np.pi - np.pi,
+        extent=[x[0] / 1000, x[-1] / 1000, y[0] / 1000, y[-1] / 1000],
+        origin="lower",
+        cmap="jet",
+    )
+    plt.colorbar(label="radians")
+    plt.title(f"Wrapped simulation value {Heading}")
+    plt.xlabel("easting (km)")
+    plt.ylabel("northing (km)")
+    plt.axis("image")
     plt.show()

--- a/main_code/runGenDeformation.py
+++ b/main_code/runGenDeformation.py
@@ -1,28 +1,48 @@
 import os
-import numpy as np
 import sys
+import numpy as np
+import matplotlib.pyplot as plt
+from PIL import Image
+
+try:
+    from scipy.io import savemat
+except Exception:  # pragma: no cover - SciPy optional
+    savemat = None
 
 parent_dir = os.path.dirname(os.path.dirname(__file__))
 sys.path.append(parent_dir)
-sys.path.append(os.path.join(parent_dir, 'deform'))
-
 
 from deform.generateDeformation import generateDeformation
-import matplotlib.pyplot as plt
 
 # Settings
-SAVEWRAP = 0
-# outputRoot = "G:/VolcanicUnrest/Atmosphere/synthesised_patches/"
-outputRoot = "C:/Users/arothera/GitHub/Synthetic_InSAR_image/set"
-os.makedirs(f"{outputRoot}/set1/unwrap/deform/", exist_ok=True)
-os.makedirs(f"{outputRoot}/set2/unwrap/deform/", exist_ok=True)
-
+SAVEWRAP = 1
+outputRoot = r"C:/Users/arothera/GitHub/Synthetic_InSAR_image/set"
+for s in ("set1", "set2"):
+    os.makedirs(os.path.join(outputRoot, s, "unwrap", "deform"), exist_ok=True)
 if SAVEWRAP == 1:
-    os.makedirs(f"{outputRoot}/set1/wrap/deform/", exist_ok=True)
-    os.makedirs(f"{outputRoot}/set2/wrap/deform/", exist_ok=True)
+    for s in ("set1", "set2"):
+        os.makedirs(os.path.join(outputRoot, s, "wrap", "deform"), exist_ok=True)
 
 halfcrop = 227 // 2
-Source_Type = 5
+Source_Type = 4
+
+
+def center_crop(arr):
+    r, c = arr.shape
+    return arr[r // 2 - halfcrop : r // 2 + halfcrop + 1,
+               c // 2 - halfcrop : c // 2 + halfcrop + 1]
+
+
+def rotate_array(arr, angle):
+    return np.array(Image.fromarray(arr).rotate(angle, resample=Image.BILINEAR, expand=False))
+
+
+def save_unwrap(base_dir, name, data):
+    path = os.path.join(base_dir, f"{name}.mat")
+    if savemat:
+        savemat(path, {"los_grid": data})
+    else:  # fall back to NumPy binary if SciPy is unavailable
+        np.save(os.path.splitext(path)[0] + ".npy", data)
 
 # Source Parameters
 Quake = {
@@ -75,21 +95,15 @@ if Source_Type == 1:
                                 # print(allName)
                                 _, los_grid = generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, 192.04, 23)
                                 los_grid = los_grid / 0.028333 * 2 * np.pi
-                                los_grid = los_grid[len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop, len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop]
-                                print(f'Range: {np.ptp(los_grid)}')
-                                if 12 < np.ptp(los_grid) < 8000:
-                                    outputDirUnwrap = f"{outputRoot}/set{2 - count % 2}/unwrapdeform/"
-                                    print(f"outputDir: {outputDirUnwrap}")
-                                    os.makedirs(outputDirUnwrap, exist_ok=True)
-                                    plt.figure()
-                                    plt.imshow(los_grid / 0.028333 * 2 * np.pi - np.pi, extent=[x[0] / 1000, x[-1] / 1000, y[0] / 1000, y[-1] / 1000], cmap='jet')
-                                    plt.colorbar(label='radians')
-                                    # plt.title(f'Wrapped Simulation (Heading: {Heading})')
-                                    plt.xlabel('Easting (km)')
-                                    plt.ylabel('Northing (km)')
-                                    plt.axis('image')
-                                    plt.show()
-                                    np.save(f"{outputDirUnwrap}{allName}.npy", los_grid)
+                                los_grid = center_crop(los_grid)
+                                if 12 < np.ptp(los_grid) < 80:
+                                    outputDirUnwrap = os.path.join(outputRoot, f"set{2 - count % 2}", "unwrap", "deform")
+                                    save_unwrap(outputDirUnwrap, allName, los_grid)
+                                    if SAVEWRAP == 1:
+                                        outputDirWrap = os.path.join(outputRoot, f"set{2 - count % 2}", "wrap", "deform")
+                                        los_grid_wrap = np.mod(los_grid, 2 * np.pi) - np.pi
+                                        los_grid_wrap = (los_grid_wrap - los_grid_wrap.min()) / np.ptp(los_grid_wrap)
+                                        plt.imsave(os.path.join(outputDirWrap, f"{allName}.png"), los_grid_wrap, cmap="gray")
                                     count += 1
 
 # Source_Type = 2: Dykes
@@ -115,11 +129,15 @@ if Source_Type == 2:
                                         print(allName)
                                         _, los_grid = generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, Heading, Incidence)
                                         los_grid = los_grid / 0.028333 * 2 * np.pi
-                                        los_grid = los_grid[len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop, len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop]
+                                        los_grid = center_crop(los_grid)
                                         if 12 < np.ptp(los_grid) < 70:
-                                            outputDirUnwrap = f"{outputRoot}/set{2 - count % 2}/unwrap/deform/"
-                                            os.makedirs(outputDirUnwrap, exist_ok=True)
-                                            np.save(f"{outputDirUnwrap}{allName}.npy", los_grid)
+                                            outputDirUnwrap = os.path.join(outputRoot, f"set{2 - count % 2}", "unwrap", "deform")
+                                            save_unwrap(outputDirUnwrap, allName, los_grid)
+                                            if SAVEWRAP == 1:
+                                                outputDirWrap = os.path.join(outputRoot, f"set{2 - count % 2}", "wrap", "deform")
+                                                los_grid_wrap = np.mod(los_grid, 2 * np.pi) - np.pi
+                                                los_grid_wrap = (los_grid_wrap - los_grid_wrap.min()) / np.ptp(los_grid_wrap)
+                                                plt.imsave(os.path.join(outputDirWrap, f"{allName}.png"), los_grid_wrap, cmap="gray")
                                             count += 1
 
 # Source_Type = 3: Rectangular Sills
@@ -140,24 +158,30 @@ if Source_Type == 3:
                                 Sill["Width"] = Width
                                 for Depth in [4, 5, 6]:
                                     Sill["Depth"] = Depth
-                                    allName = f"Type{Source_Type}_dip{Dip}_strike{Strike}_opening{Opening}_length{Length}_width{Width}_depth{Depth}"
-                                    if count < maxnum:
-                                        print(allName)
-                                        _, los_grid = generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, Heading, Incidence)
-                                        los_grid = los_grid / 0.028333 * 2 * np.pi
-                                        los_grid = los_grid[len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop, len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop]
-                                        if 12 < np.ptp(los_grid) < 50:
-                                            outputDirUnwrap = f"{outputRoot}/set{2 - count % 2}/unwrap/deform/"
-                                            os.makedirs(outputDirUnwrap, exist_ok=True)
-                                            np.save(f"{outputDirUnwrap}{allName}.npy", los_grid)
-                                            count += 1
+                                    for Rotate in range(0, 360, 72):
+                                        allName = f"Type{Source_Type}_dip{Dip}_strike{Strike}_opening{Opening}_length{Length}_width{Width}_depth{Depth}_rotate{Rotate}"
+                                        if count < maxnum:
+                                            print(allName)
+                                            _, los_grid = generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, Heading, Incidence)
+                                            los_grid = los_grid / 0.028333 * 2 * np.pi
+                                            los_grid = rotate_array(los_grid, Rotate)
+                                            los_grid = center_crop(los_grid)
+                                            if 12 < np.ptp(los_grid) < 50:
+                                                outputDirUnwrap = os.path.join(outputRoot, f"set{2 - count % 2}", "unwrap", "deform")
+                                                save_unwrap(outputDirUnwrap, allName, los_grid)
+                                                if SAVEWRAP == 1:
+                                                    outputDirWrap = os.path.join(outputRoot, f"set{2 - count % 2}", "wrap", "deform")
+                                                    los_grid_wrap = np.mod(los_grid, 2 * np.pi) - np.pi
+                                                    los_grid_wrap = (los_grid_wrap - los_grid_wrap.min()) / np.ptp(los_grid_wrap)
+                                                    plt.imsave(os.path.join(outputDirWrap, f"{allName}.png"), los_grid_wrap, cmap="gray")
+                                                count += 1
 
 # Source_Type = 4: Magma Chamber
 if Source_Type == 4:
     count = 1
     for Incidence in [33]:
         for Heading in range(5, 331, 40):
-            for Volume in [6, 6.5, 6.7, 7, 7.2, 7.5]:
+            for Volume in [v + 0.2 for v in [6, 6.5, 6.7, 7, 7.2, 7.5]]:
                 Mogi["Volume"] = 10**Volume
                 VolumeName = f"vol1e{Volume:.1f}"
                 depth_range = (
@@ -172,12 +196,15 @@ if Source_Type == 4:
                     if count < maxnum:
                         print(allName)
                         _, los_grid = generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, Heading, Incidence)
-                        los_grid = los_grid / 0.028333 * 2 * np.pi
-                        los_grid = los_grid[len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop, len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop]
-                        if 10 < np.ptp(los_grid) < 20:
-                            outputDirUnwrap = f"{outputRoot}/set{2 - count % 2}/unwrap/deform/"
-                            os.makedirs(outputDirUnwrap, exist_ok=True)
-                            np.save(f"{outputDirUnwrap}{allName}.npy", los_grid)
+                        los_grid = center_crop(los_grid)
+                        if 0.10 < np.ptp(los_grid) < 20:
+                            outputDirUnwrap = os.path.join(outputRoot, f"set{2 - count % 2}", "unwrap", "deform")
+                            save_unwrap(outputDirUnwrap, allName, los_grid)
+                            if SAVEWRAP == 1:
+                                outputDirWrap = os.path.join(outputRoot, f"set{2 - count % 2}", "wrap", "deform")
+                                los_grid_wrap = np.mod(los_grid, 2 * np.pi) - np.pi
+                                los_grid_wrap = (los_grid_wrap - los_grid_wrap.min()) / np.ptp(los_grid_wrap)
+                                plt.imsave(os.path.join(outputDirWrap, f"{allName}.png"), los_grid_wrap, cmap="gray")
                             count += 1
 
 # Source_Type = 5: Pressurized Penny-shaped Horizontal Crack
@@ -197,10 +224,14 @@ if Source_Type == 5:
                                 print(allName)
                                 _, los_grid = generateDeformation(Source_Type, x, y, Quake, Dyke, Sill, Mogi, Penny, Heading, Incidence)
                                 los_grid = los_grid / 0.028333 * 2 * np.pi
-                                los_grid = np.rot90(los_grid, Rotate // 90)
-                                los_grid = los_grid[len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop, len(los_grid)//2 - halfcrop:len(los_grid)//2 + halfcrop]
+                                los_grid = rotate_array(los_grid, Rotate)
+                                los_grid = center_crop(los_grid)
                                 if 10 < np.ptp(los_grid) < 30:
-                                    outputDirUnwrap = f"{outputRoot}/set{2 - count % 2}/unwrap/deform/"
-                                    os.makedirs(outputDirUnwrap, exist_ok=True)
-                                    np.save(f"{outputDirUnwrap}{allName}.npy", los_grid)
+                                    outputDirUnwrap = os.path.join(outputRoot, f"set{2 - count % 2}", "unwrap", "deform")
+                                    save_unwrap(outputDirUnwrap, allName, los_grid)
+                                    if SAVEWRAP == 1:
+                                        outputDirWrap = os.path.join(outputRoot, f"set{2 - count % 2}", "wrap", "deform")
+                                        los_grid_wrap = np.mod(los_grid, 2 * np.pi) - np.pi
+                                        los_grid_wrap = (los_grid_wrap - los_grid_wrap.min()) / np.ptp(los_grid_wrap)
+                                        plt.imsave(os.path.join(outputDirWrap, f"{allName}.png"), los_grid_wrap, cmap="gray")
                                     count += 1


### PR DESCRIPTION
## Summary
- Ported station-geometry constants, singularity checks, and cross-term handling from dc3d6.m into dc3d6.py
- Incorporated c2_tt cross-term into strike-, dip-, and tensile-slip components and reinitialized per-quadrant contributions
- Fixed quadrant parity so subfault contributions alternate add/subtract like the MATLAB routine
- Reworked disloc3d3.py to mirror MATLAB by warning on above-surface faults and returning underlying error codes

## Testing
- `python -m py_compile deform/dc3d6.py`
- `python - <<'PY'
import numpy as np
from deform.dc3d6 import dc3d6
ux, uy, uz, err = dc3d6(0.5, np.array([1.0]), np.array([1.0]), 1.0, 30.0, -1.0, 1.0, -1.0, 1.0, 1.0, 0.0, 0.0)
print(ux, uy, uz, err)
PY`
- `python -m py_compile deform/disloc3d3.py`
- `python - <<'PY'
import numpy as np
from deform.disloc3d3 import disloc3d3
m = np.array([[0.0],[0.0],[0.0],[30.0],[0.0],[1.0],[2.0],[1.0],[3.0],[1.0]])
x = np.array([[1.0],[1.0]])
U, flag = disloc3d3(m, x, 1.0, 1.0)
print(U)
print('flag', flag)
PY`

-- This is a first test of ChatGPT Codex's ability to convert matlab files to python
